### PR TITLE
fix tab.title is undefined

### DIFF
--- a/lib/TabList.js
+++ b/lib/TabList.js
@@ -45,8 +45,8 @@ class TabList {
     }
 
     for (let tab of this.list) {
-      if (tab.title.toLowerCase().match(new RegExp('.*' + this.query + '.*')) 
-          || tab.url.toLowerCase().match(new RegExp('.*' + this.query + '.*'))) {
+      if (tab.title !== undefined && (tab.title.toLowerCase().match(new RegExp('.*' + this.query + '.*')) 
+          || tab.url.toLowerCase().match(new RegExp('.*' + this.query + '.*')))) {
         filteredList.push(tab);
       }
     }


### PR DESCRIPTION
If the tab is "about:blank" the title is undefined and the extension fail.

I've just add a test to avoid this crash.